### PR TITLE
fix: Small typo

### DIFF
--- a/COMMITMSG
+++ b/COMMITMSG
@@ -1,0 +1,8 @@
+fix: Small typo
+
+- public\index.html: 'two-dimensonal'->'two-dimensional'
+- public\_index.html: 'two-dimensonal'->'two-dimensional'
+
+Fixes #14
+
+Signed-off-by: Vedant Madane <6527493+VedantMadane@users.noreply.github.com>

--- a/COMMITMSG
+++ b/COMMITMSG
@@ -1,8 +1,0 @@
-fix: Small typo
-
-- public\index.html: 'two-dimensonal'->'two-dimensional'
-- public\_index.html: 'two-dimensonal'->'two-dimensional'
-
-Fixes #14
-
-Signed-off-by: Vedant Madane <6527493+VedantMadane@users.noreply.github.com>

--- a/public/_index.html
+++ b/public/_index.html
@@ -137,7 +137,7 @@ input[type=range]:focus::-ms-fill-upper {
     <dt-include src="assets/playground.html"></dt-include>
   </div>
   <dt-byline></dt-byline>
-  <p>A popular method for exploring high-dimensional data is something called t-SNE, introduced by <dt-cite key="maaten2008visualizing">van der Maaten and Hinton in 2008</dt-cite>. The technique has become widespread in the field of machine learning, since it has an almost magical ability to create compelling two-dimensonal "maps" from data with hundreds or even thousands of dimensions.
+  <p>A popular method for exploring high-dimensional data is something called t-SNE, introduced by <dt-cite key="maaten2008visualizing">van der Maaten and Hinton in 2008</dt-cite>. The technique has become widespread in the field of machine learning, since it has an almost magical ability to create compelling two-dimensional "maps" from data with hundreds or even thousands of dimensions.
 Although impressive, these images can be tempting to misread. The purpose of this note is to prevent some common misreadings.</p>
 
   <p>We'll walk through a series of simple examples to illustrate what t-SNE diagrams can and cannot show. The t-SNE technique really is useful—but only if you know how to interpret it.</p>

--- a/public/index.html
+++ b/public/index.html
@@ -688,7 +688,7 @@ input[type=range]:focus::-ms-fill-upper {
 </dt-include>
   </div>
   <dt-byline></dt-byline>
-  <p>A popular method for exploring high-dimensional data is something called t-SNE, introduced by <dt-cite key="maaten2008visualizing">van der Maaten and Hinton in 2008</dt-cite>. The technique has become widespread in the field of machine learning, since it has an almost magical ability to create compelling two-dimensonal "maps" from data with hundreds or even thousands of dimensions.
+  <p>A popular method for exploring high-dimensional data is something called t-SNE, introduced by <dt-cite key="maaten2008visualizing">van der Maaten and Hinton in 2008</dt-cite>. The technique has become widespread in the field of machine learning, since it has an almost magical ability to create compelling two-dimensional "maps" from data with hundreds or even thousands of dimensions.
 Although impressive, these images can be tempting to misread. The purpose of this note is to prevent some common misreadings.</p>
 
   <p>We'll walk through a series of simple examples to illustrate what t-SNE diagrams can and cannot show. The t-SNE technique really is useful—but only if you know how to interpret it.</p>


### PR DESCRIPTION
## Summary

Small typo

## Changes

- public\index.html: 'two-dimensonal'->'two-dimensional'
- public\_index.html: 'two-dimensonal'->'two-dimensional'

Fixes #14
